### PR TITLE
CodeGen 过滤掉关键字op_explicit

### DIFF
--- a/Assets/Slua/Editor/ICustomExportPost.cs
+++ b/Assets/Slua/Editor/ICustomExportPost.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace SLua{
+	public interface ICustomExportPost {
+
+	}
+}

--- a/Assets/Slua/Editor/ICustomExportPost.cs.meta
+++ b/Assets/Slua/Editor/ICustomExportPost.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0517ba8e84e8c48869fc381b0fe501a3
+timeCreated: 1445479148
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -1472,7 +1472,7 @@ namespace SLua
 			if (method.Name != "GetType" && method.Name != "GetHashCode" && method.Name != "Equals" &&
 			    method.Name != "ToString" && method.Name != "Clone" &&
 			    method.Name != "GetEnumerator" && method.Name != "CopyTo" &&
-			    method.Name != "op_Implicit" &&
+			    method.Name != "op_Implicit" && method.Name != "op_Explicit" &&
 			    !method.Name.StartsWith("get_", StringComparison.Ordinal) &&
 			    !method.Name.StartsWith("set_", StringComparison.Ordinal) &&
 			    !method.Name.StartsWith("add_", StringComparison.Ordinal) &&

--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -1742,12 +1742,15 @@ namespace SLua
 				file.Write("\t");
 			
 			
-			if (args.Length == 0)
-				file.WriteLine(fmt);
+			if (args.Length == 0){
+				file.Write(fmt);
+				file.Write("\r\n");  //TODO add by zilch,try to make win&mac generate same files.
+			}
 			else
 			{
 				string line = string.Format(fmt, args);
-				file.WriteLine(line);
+				file.Write(line);
+				file.Write("\r\n");
 			}
 			
 			if (fmt.EndsWith("{")) indent++;

--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -273,6 +273,19 @@ namespace SLua
             }
 
             CustomExport.OnAddCustomClass(fun);
+
+			//detect interface ICustomExportPost,and call OnAddCustomClass
+			assembly = System.Reflection.Assembly.Load("Assembly-CSharp-Editor");
+			types = assembly.GetExportedTypes();
+			foreach (Type t in types)
+			{
+				if(typeof(ICustomExportPost).IsAssignableFrom(t)){
+					System.Reflection.MethodInfo method =  t.GetMethod("OnAddCustomClass",System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+					if(method != null){
+						method.Invoke(null,new object[]{fun});
+					}
+				}
+			}
 			
 			GenerateBind(exports, "BindCustom", 3, path);
             if(autoRefresh)


### PR DESCRIPTION
如果一个c#类里包含关键字expicit,则导出的类会报错.
cannot explicitly call operator or accessor
故在codegen的时候过滤掉此关键字
